### PR TITLE
Refactor

### DIFF
--- a/lib/rpl-client.js
+++ b/lib/rpl-client.js
@@ -1,54 +1,11 @@
 const io = require("socket.io-client");
 
 class Rpl {
-  constructor({ host }) {
-    this.host = host;
-
-    this.socket = io(this.host);
-
-    this.socket.on("connect", () => {
-      console.log("Connected to rpl server");
-    });
+  constructor() {
+    console.log(
+      "COPY CODE FROM /public/js/rpl-client.js TO /lib/rpl-client.js"
+    );
   }
-
-  publish(message) {
-    this.socket.emit("message", message);
-  }
-
-
-  on(eventName, callback) {
-    this.socket.on(eventName, (data) => {
-      callback(data);
-    });
-  }
-
-  subscribe(channel) {
-    this.socket.emit("subscribe", channel);
-    return new Channel(this.socket, channel);
-  }
-
-  unsubscribe(channel) {
-    this.socket.emit("unsubscribe", channel);
-  }
-
-  disconnect() {
-    this.socket.close();
-  }
-}
-
-class Channel {
-  constructor(socket, channel) {
-    this.socket = socket;
-    this.channel = channel;
-  }
-
-  // bind(eventName, callback) {
-  //   this.socket.on(eventName, (payload) => {
-  //     if (payload.channel == this.channel) {
-  //       callback(payload.data);
-  //     }
-  //   });
-  // }
 }
 
 module.exports = Rpl;

--- a/public/js/rpl-client.js
+++ b/public/js/rpl-client.js
@@ -1,19 +1,26 @@
-
 class Rpl {
-  constructor({ host }) {
+  constructor({ host, channel }) {
     this.host = host;
-
+    this.channel = channel;
     this.socket = io(this.host);
 
     this.socket.on("connect", () => {
-      console.log("Connected to rpl server");
+      console.log("Client: Connected to rpl server");
     });
+
+    this.socket.emit("subscribe", this.channel);
   }
 
-  publish(eventType, message) {
-    this.socket.emit(eventType, message);
+  // Client emit actions will always have a channel in the payload
+  // TODO: consider changing this to "publish" - Check the PubNub method options
+  publish(eventType, data) {
+    const payload = {
+      channel: this.channel,
+      eventType,
+      data,
+    };
+    this.socket.emit("publish", payload);
   }
-
 
   on(eventName, callback) {
     this.socket.on(eventName, (data) => {
@@ -21,33 +28,7 @@ class Rpl {
     });
   }
 
-  subscribe(channel) {
-    this.socket.emit("subscribe", channel);
-    return new Channel(this.socket, channel);
-  }
-
-  unsubscribe(channel) {
-    this.socket.emit("unsubscribe", channel);
-  }
-
   disconnect() {
     this.socket.close();
   }
 }
-
-class Channel {
-  constructor(socket, channel) {
-    this.socket = socket;
-    this.channel = channel;
-  }
-
-  bind(eventName, callback) {
-    this.socket.on(eventName, (payload) => {
-      console.log(eventName, payload);
-      if (payload.channel == this.channel) {
-        callback(payload.data);
-      }
-    });
-  }
-}
-

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,38 +1,49 @@
-const rpl = new Rpl({ host: "http://localhost:3000/" });
-const channel = rpl.subscribe("balloon");
-channel.bind("thought", (data) => console.log("what is this? ", data));
+// Log connection status
+const message = `Client: front end of user-app opened in browser`;
+const line = new Array(message.length).fill("-").join("");
+console.log(`${line}\n${message}\n${line}`);
 
+// Create rpl instance & subscribe to specified channel
+// TODO: Is it ok to require users to subscribe to 1 and only 1 channel per instance? (check PubNub)
+const rpl = new Rpl({
+  host: "http://localhost:3000/",
+  channel: "balloon",
+});
+
+// Grab HTML elements
 const form = document.querySelector("form");
 const thought = document.getElementById("thought");
 const thoughts = document.getElementById("thoughts");
 
-
-form.addEventListener("submit", e => {
-  console.log('reached the submit handler');
+// Handle form submit event
+form.addEventListener("submit", (e) => {
   e.preventDefault();
-
   if (thought.value) {
     rpl.publish("thought", thought.value);
     thought.value = "";
   }
-})
+});
 
-rpl.on('thought', (msg) => {
-  let thought = document.createElement('LI');
-  thought.innerHTML = msg
-  thoughts.insertBefore(thought, thoughts.children[0])
-  updateStyle()
-})
+// Handle socket.io event
+rpl.on("thought", (msg) => {
+  let thought = document.createElement("LI");
+  thought.innerHTML = msg;
+  thoughts.insertBefore(thought, thoughts.children[0]);
+  updateStyle();
+});
 
+// "info" eventType indicates informational message form the server
+// TODO: should we have a few "reserved" words for this type of thing?
+rpl.on("info", (message) => {
+  console.log(message);
+});
+
+// Helper function to limit the list to 10 messages and style them
 const updateStyle = () => {
   let thoughts = [...document.querySelectorAll("li")];
   for (let i = 0; i < thoughts.length; i++) {
     const thought = thoughts[i];
-
-    if (i > 9) {
-      thought.parentElement.removeChild(thought);
-    }
-
+    if (i > 9) thought.parentElement.removeChild(thought);
     thought.style.color = `rgba(0, 0, 0, ${(10 - i) / 10})`;
   }
-}
+};

--- a/user-app.js
+++ b/user-app.js
@@ -22,5 +22,7 @@ app.get("/", (req, res) => {
 });
 
 app.listen(port, () => {
-  console.log(`Server started on port ${port}. press Ctrl + C to terminate`);
+  const message = `Client: user-app started on port ${port}`;
+  const line = new Array(message.length).fill("-").join("");
+  console.log(`${line}\n${message}\n${line}`);
 });


### PR DESCRIPTION
- Made "server running" message fancier
- Removed code from `lib/rpl-client.js` and added reminder to add it back in later

**rpl-client.js**
- Require channel when creating rpl instance
    - I believe this is how PubNub does it
    - Need to figure out if/how to allow multuiple channel subscriptions
- made console logs more descriptive
- removed `subscribe` and `unsubscribe` methods
    - if we require the channel at instantiation, we don't relly need a public subscrbe method
    - If we aren't allowing a public subscribe method, I don't think we'll have an unsubscribe
    - this could be totally off base and we might need moer dynamic subscribe/unsubscribe options
- completely removed channel class
- changes publish method to pass in payload with channel name

**script.js**
- added fancy "client connected" console log
- require channel parameter when creating rpl instance